### PR TITLE
Refactor to split data model that user-profile-story and created-story

### DIFF
--- a/src/core/event/BaseEvent.ts
+++ b/src/core/event/BaseEvent.ts
@@ -4,7 +4,7 @@ import { convertIsoToYearAndMonth } from "../../lib/date";
 
 export type BaseEvent = EventInput & {
   extendedProps: {
-    calendarId: string;
+    calendarId: string | undefined;
     storyId: string;
   };
 };

--- a/src/core/event/createProfileEvents.ts
+++ b/src/core/event/createProfileEvents.ts
@@ -17,7 +17,7 @@ export const createProfileEvents = ({
 }: {
   startDate: Date;
   storyId: string;
-  calendarId: string;
+  calendarId: string | undefined;
 }): BaseEvent[] => {
   // get year num
   const startYear = new Date(startDate).getFullYear();
@@ -71,7 +71,7 @@ const getLastYear = () => {
 const createWorkingHolidayLimitEvents = (
   birthday: Date,
   storyId: string,
-  calendarId: string
+  calendarId: string | undefined
 ): BaseEvent[] => {
   const lastYearDate = addYears(
     birthday,

--- a/src/core/resource/BaseResource.ts
+++ b/src/core/resource/BaseResource.ts
@@ -7,7 +7,7 @@ import {
 
 export type BaseResource = {
   id: string;
-  calendarId: string;
+  calendarId?: string;
   [FIELD]: string;
   [NAME_OF_STORY_ID]: string;
   [NAME_OF_ORDER]?: number;

--- a/src/core/resource/createProfileResources.ts
+++ b/src/core/resource/createProfileResources.ts
@@ -12,10 +12,8 @@ import {
 import { BaseResource } from "./BaseResource";
 
 export const createProfileResources = ({
-  calendarId,
   storyId,
 }: {
-  calendarId: string;
   storyId: string;
 }): BaseResource[] => [
   {
@@ -23,7 +21,7 @@ export const createProfileResources = ({
     [FIELD]: "Age",
     [NAME_OF_STORY_ID]: storyId,
     [NAME_OF_ORDER]: 0,
-    calendarId,
+    calendarId: undefined,
     eventBorderColor: DARK_BLUE,
   },
   {
@@ -31,7 +29,7 @@ export const createProfileResources = ({
     [FIELD]: "Working Holiday",
     [NAME_OF_STORY_ID]: storyId,
     [NAME_OF_ORDER]: 1,
-    calendarId,
+    calendarId: undefined,
     eventBorderColor: DARK_BLUE,
   },
 ];

--- a/src/core/story/BaseStory.ts
+++ b/src/core/story/BaseStory.ts
@@ -5,7 +5,7 @@ import { uuid } from "../../lib/uuid";
 
 export type BaseStory = {
   id: string;
-  calendarId: string;
+  calendarId: string | undefined;
   events: BaseEvent[];
   resources: BaseResource[];
   name: string;

--- a/src/core/story/ProfileStory/createProfileStory.ts
+++ b/src/core/story/ProfileStory/createProfileStory.ts
@@ -6,18 +6,20 @@ import { createProfileEvents } from "../../event/createProfileEvents";
 
 export const createProfileStory = ({
   birth,
-  calendarId,
 }: {
   birth: string | Date;
-  calendarId: string;
 }): ProfileStory => {
   const _birth = new Date(birth);
   const storyId = PROFILE_ID;
   return {
     id: storyId,
-    calendarId,
+    calendarId: undefined,
     name: createStoryName(_birth),
-    resources: createProfileResources({ calendarId, storyId }),
-    events: createProfileEvents({ calendarId, storyId, startDate: _birth }),
+    resources: createProfileResources({ storyId }),
+    events: createProfileEvents({
+      calendarId: undefined,
+      storyId,
+      startDate: _birth,
+    }),
   };
 };

--- a/src/hooks/useUserCalendar.ts
+++ b/src/hooks/useUserCalendar.ts
@@ -8,8 +8,9 @@ import { createUserCalendar } from "../core/calendar/UserCalendar/createUserCale
 import {
   updateCalendarsAction,
   addEventAction,
-  selectUserCalendar,
 } from "../redux/features/userCalendars";
+import { updateAction as updateUserProfileStoryAction } from "../redux/features/userProfileStory";
+import { selectUserCalendar } from "../redux/selectors";
 import { MY_CALENDAR_ID } from "../constants/fullcalendar/settings";
 
 export const useUserCalendar = () => {
@@ -19,13 +20,14 @@ export const useUserCalendar = () => {
   const init = React.useCallback(
     (birthday: string | Date) => {
       const calendarId = MY_CALENDAR_ID; // TODO: use selected my calendar id not constant value
-      const story = createProfileStory({ birth: birthday, calendarId });
+      const story = createProfileStory({ birth: birthday });
       const _calendar = createUserCalendar({
         id: calendarId,
-        stories: [story],
+        stories: [],
       });
       const _calendars = [_calendar];
       dispatch(updateCalendarsAction({ calendars: _calendars }));
+      dispatch(updateUserProfileStoryAction({ story }));
     },
     [dispatch]
   );

--- a/src/redux/features/templateCalendarTable.ts
+++ b/src/redux/features/templateCalendarTable.ts
@@ -26,6 +26,7 @@ type UpsertPublicCollegeStoriesPayload = {
   options: TemplateOption;
 };
 
+// TODO: rename to remove table. it expresses data type but not appropriate as name.
 const templateCalendarTable = createSlice({
   name: "templateCalendarTable",
   initialState: {

--- a/src/redux/features/userProfileStory.ts
+++ b/src/redux/features/userProfileStory.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { BaseStory } from "../../core/story/BaseStory";
+import { RootState } from "../rootReducer";
+
+type UpdatePayload = {
+  story: BaseStory;
+};
+
+const slices = createSlice({
+  name: "userProfileStory",
+  initialState: {
+    story: undefined as BaseStory | undefined,
+  },
+  reducers: {
+    update(state, action: PayloadAction<UpdatePayload>) {
+      const { story } = action.payload;
+      state.story = story;
+    },
+  },
+});
+
+export const selectUserProfileStory = (state: RootState) =>
+  state.features.userProfileStory.story;
+
+export const { update: updateAction } = slices.actions;
+
+export default slices.reducer;

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -4,6 +4,7 @@ import userReducer from "./features/user";
 import templateCalendarTableReducer from "./features/templateCalendarTable";
 import templateOptionReducer from "./features/templateOption";
 import userCalendarsReducer from "./features/userCalendars";
+import userProfileStoryReducer from "./features/userProfileStory";
 import eventModalReducer from "./ui/eventModal";
 import storyModalReducer from "./ui/storyModal";
 
@@ -16,6 +17,7 @@ const featuresReducer = combineReducers({
   templateCalendar: templateCalendarTableReducer,
   templateOption: templateOptionReducer,
   userCalendars: userCalendarsReducer,
+  userProfileStory: userProfileStoryReducer,
   user: userReducer,
 });
 

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -1,0 +1,16 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { selectUserCalendar as selectRowUserCalendar } from "./features/userCalendars";
+import { selectUserProfileStory } from "./features/userProfileStory";
+
+export const selectUserCalendar = createSelector(
+  selectRowUserCalendar,
+  selectUserProfileStory,
+  (rowUserCalendar, userProfileStory) => {
+    if (!rowUserCalendar) return rowUserCalendar;
+    if (!userProfileStory) return rowUserCalendar;
+    return {
+      ...rowUserCalendar,
+      stories: [userProfileStory, ...rowUserCalendar.stories],
+    };
+  }
+);


### PR DESCRIPTION
Split data model in redux store

```yaml
// data model

// before
calendar:
  stories: [userProfileStory, ...myCustomStories]

// after
calendar:
  stories: [...myCustomStories]
userProfileStory:
  story: <data-here>

// when to select this data
// combine [userProfileStory.story.data, ...calendar.stories] to use re-select
```

